### PR TITLE
Fixes for STOR-1185 and STOR-1186

### DIFF
--- a/config/systemd/storm-globus-gridftp.service
+++ b/config/systemd/storm-globus-gridftp.service
@@ -2,6 +2,7 @@
 Description=StoRM Globus GridFTP service
 
 [Service]
+EnvironmentFile=-/etc/sysconfig/storm-globus-gridftp
 User=root
 Type=forking
 ExecStart=/usr/sbin/globus-gridftp-server -S

--- a/config/systemd/storm-globus-gridftp.service
+++ b/config/systemd/storm-globus-gridftp.service
@@ -6,7 +6,7 @@ EnvironmentFile=-/etc/sysconfig/storm-globus-gridftp
 User=root
 Type=forking
 ExecStart=/usr/sbin/globus-gridftp-server -S
-KillMode=process
+KillMode=control-group
 
 [Install]
 WantedBy=multi-user.target

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 AC_PREREQ(2.57)
-AC_INIT([storm globus gridftp server], [1.2.3], [vincenzo.vagnoni@bo.infn.it])
+AC_INIT([storm globus gridftp server], [1.2.4], [vincenzo.vagnoni@bo.infn.it])
 AC_CONFIG_AUX_DIR([./project])
 AC_CONFIG_SRCDIR([src/dsi_StoRM.h])
 AM_INIT_AUTOMAKE


### PR DESCRIPTION
Changes to systemd unit:

- load environment variables from /etc/sysconfig/storm-globus-gridftp
- used KillMode control-group and not process value to avoid orphan transfer processes